### PR TITLE
[HaxelibVersions.hx] Add `dir` to result

### DIFF
--- a/source/funkin/util/macro/HaxelibVersions.hx
+++ b/source/funkin/util/macro/HaxelibVersions.hx
@@ -37,7 +37,7 @@ class HaxelibVersions
         var innerText:String = switch (type)
         {
           case 'git':
-            '${pkg.link}:${pkg.branch ?? 'None'}';
+            '${pkg.link}/${pkg.dir ?? ''}:${pkg.branch ?? 'None'}';
           case 'haxelib':
             '${pkg.version ?? 'None'}';
           default:


### PR DESCRIPTION
this pr is for https://github.com/FunkinCrew/Funkin/pull/3741

this adds the `dir` property to the result in the macro.